### PR TITLE
changes needed in cobra to support the coreos/pflags

### DIFF
--- a/cobra_test.go
+++ b/cobra_test.go
@@ -244,8 +244,8 @@ func TestChildSameNamePrefix(t *testing.T) {
 }
 
 func TestFlagLong(t *testing.T) {
-	noRRSetupTest("echo --intone=13 something here")
-
+	str := noRRSetupTest("echo --intone=13 something here")
+	fmt.Println(str.Output)
 	if strings.Join(te, " ") != "something here" {
 		t.Errorf("flags didn't leave proper args remaining..%s given", te)
 	}
@@ -258,7 +258,7 @@ func TestFlagLong(t *testing.T) {
 }
 
 func TestFlagShort(t *testing.T) {
-	noRRSetupTest("echo -i13 something here")
+	noRRSetupTest("echo -i 13 something here")
 
 	if strings.Join(te, " ") != "something here" {
 		t.Errorf("flags didn't leave proper args remaining..%s given", te)
@@ -282,7 +282,7 @@ func TestFlagShort(t *testing.T) {
 		t.Errorf("default flag value changed, 234 expected, %d given", flagi2)
 	}
 
-	noRRSetupTest("print -i99 one two")
+	noRRSetupTest("print -i=99 one two")
 
 	if strings.Join(tp, " ") != "one two" {
 		t.Errorf("flags didn't leave proper args remaining..%s given", tp)
@@ -309,7 +309,7 @@ func TestChildCommandFlags(t *testing.T) {
 		t.Errorf("invalid flag should generate error")
 	}
 
-	if !strings.Contains(r.Output, "unknown shorthand") {
+	if !strings.Contains(r.Output, "unknown flag") {
 		t.Errorf("Wrong error message displayed, \n %s", r.Output)
 	}
 
@@ -332,16 +332,6 @@ func TestChildCommandFlags(t *testing.T) {
 		t.Errorf("Wrong error message displayed, \n %s", r.Output)
 	}
 
-	// Testing flag with invalid input
-	r = noRRSetupTest("echo -i10E")
-
-	if r.Error == nil {
-		t.Errorf("invalid input should generate error")
-	}
-
-	if !strings.Contains(r.Output, "invalid argument \"10E\" for -i10E") {
-		t.Errorf("Wrong error message displayed, \n %s", r.Output)
-	}
 }
 
 func TestTrailingCommandFlags(t *testing.T) {
@@ -430,8 +420,8 @@ func TestRootHelp(t *testing.T) {
 func TestFlagsBeforeCommand(t *testing.T) {
 	// short without space
 	x := fullSetupTest("-i10 echo")
-	if x.Error != nil {
-		t.Errorf("Valid Input shouldn't have errors, got:\n %q", x.Error)
+	if x.Error == nil {
+		t.Errorf("Invalid Input should report errors")
 	}
 
 	// short (int) with equals
@@ -451,7 +441,7 @@ func TestFlagsBeforeCommand(t *testing.T) {
 
 	// With parsing error properly reported
 	x = fullSetupTest("-i10E echo")
-	if !strings.Contains(x.Output, "invalid argument \"10E\" for -i10E") {
+	if !strings.Contains(x.Output, "unknown flag") {
 		t.Errorf("Wrong error message displayed, \n %s", x.Output)
 	}
 

--- a/cobra_test.go
+++ b/cobra_test.go
@@ -244,8 +244,8 @@ func TestChildSameNamePrefix(t *testing.T) {
 }
 
 func TestFlagLong(t *testing.T) {
-	str := noRRSetupTest("echo --intone=13 something here")
-	fmt.Println(str.Output)
+	noRRSetupTest("echo --intone=13 something here")
+
 	if strings.Join(te, " ") != "something here" {
 		t.Errorf("flags didn't leave proper args remaining..%s given", te)
 	}

--- a/command.go
+++ b/command.go
@@ -23,7 +23,7 @@ import (
 	"os"
 	"strings"
 
-	flag "github.com/spf13/pflag"
+	flag "github.com/joshi4/pflag"
 )
 
 // Command is just that, a command for your application.

--- a/command.go
+++ b/command.go
@@ -281,7 +281,6 @@ func (c *Command) Find(arrs []string) (*Command, []string, error) {
 	innerfind = func(c *Command, args []string) (*Command, []string) {
 		if len(args) > 0 && c.HasSubCommands() {
 			argsWOflags := stripFlags(args)
-			// fmt.Println("Arguments without flags are ", argsWOflags)
 			if len(argsWOflags) > 0 {
 				matches := make([]*Command, 0)
 				for _, cmd := range c.commands {
@@ -333,7 +332,6 @@ func (c *Command) findAndExecute(args []string) (err error) {
 	if e != nil {
 		return e
 	}
-	// fmt.Println("about to execute ", cmd.Name())
 	return cmd.execute(a)
 }
 
@@ -378,17 +376,17 @@ func (c *Command) errorMsgFromParse() string {
 	}
 }
 
-//Takes the command line arguments in all the various forms that
-//etcdctl supports and converts the flags to POSIX style flags
+// Takes the command line arguments in all the various forms that
+// etcdctl supports and converts the flags to POSIX style flags
 // without any difference in the long and short flags.
-func (c *Command) reformatArgs(args []string) []string {
+func (c *Command) reformatArgs(args []string) ([]string, error) {
 
 	// if args[i] has prefix of - and contains a = there is nothing to do.
 	// if args[i] has no prefix then it's a command and do nothing.
 	// if args[i] has a prefix of - but does not contain a = then
 	// if args[i] is a boolean flag ; do nothing
 	// otherwise join args[i] and args[i+1]
-	// if the value is not present, do nothing error will be caught later on.
+	// if the value is not present, and its not a boolean flag, raise an error.
 
 	_, booleanFlagMap := c.getAllBooleanFlags()
 
@@ -407,36 +405,36 @@ func (c *Command) reformatArgs(args []string) []string {
 				break
 			}
 
-			if !strings.Contains(args[i], "=") { // without an equal to sign in it.
+			if !strings.Contains(args[i], "=") {
 				num_minuses := 1
 				if len(args[i]) > 1 && args[i][1] == '-' {
 					num_minuses = 2
 				}
-				if _, ok := booleanFlagMap[args[i][num_minuses:]]; !ok { // its not a boolean flag.
-					if i+1 < argNumber { // there should be a value following it.
+				if _, ok := booleanFlagMap[args[i][num_minuses:]]; !ok {
+					if i+1 < argNumber {
 						modifiedArgs = append(modifiedArgs, strings.Join(args[i:i+2], "="))
-						// j += 1
 						i = i + 1 // the loop will increment once as well giving us desired i+2
 						continue
+					} else { // it's not a boolean flag but has no value specified (may not be a flag as well)
+						return nil, errors.New("unknown flag or unspecified value for non-boolean flag")
+
 					}
 				} else { // its a boolean flag without a value specified so must be set to true.
 					modifiedArgs = append(modifiedArgs, args[i])
-					// j += 1
+
 				}
-			} else { // it's a flag with an equal to sign in it.
+			} else { // it's a flag with an = sign in it, no need to reformat
 				modifiedArgs = append(modifiedArgs, args[i])
-				// j += 1
 			}
 
 			continue
 		}
 
 		modifiedArgs = append(modifiedArgs, args[i])
-		// j += 1
 
 	}
 
-	return modifiedArgs
+	return modifiedArgs, nil
 
 }
 
@@ -454,9 +452,6 @@ func (c *Command) Execute() (err error) {
 	// overriding
 	c.initHelp()
 
-	// solution is: convert args to have -flag val -> -flag=val
-	// that should be the last thing I have to take care of.
-
 	var args []string
 
 	if len(c.args) == 0 {
@@ -465,8 +460,11 @@ func (c *Command) Execute() (err error) {
 		args = c.args
 	}
 
-	//reformat the arguments here:
-	args = c.reformatArgs(args)
+	args, err = c.reformatArgs(args)
+
+	if err != nil {
+		return err
+	}
 
 	if len(args) == 0 {
 		// Only the executable is called and the root is runnable, run it
@@ -476,12 +474,7 @@ func (c *Command) Execute() (err error) {
 			c.Usage()
 		}
 	} else {
-		// fmt.Println("args to findAndExecute are : ", args)
 		err = c.findAndExecute(args)
-		if err != nil {
-
-			// fmt.Println("finished findAndExecute with error = ", err.Error())
-		}
 	}
 
 	// Now handle the case where the root is runnable and only flags are provided
@@ -803,14 +796,11 @@ func (c *Command) getAllCommands() []*Command {
 	return baseSlice
 }
 
-// call only on the root.
 func (c *Command) getAllBooleanFlags() (error, map[string]struct{}) {
-
 	if c.Root().Name() != c.Name() {
 		return errors.New("Error: getAllBooleanFlags not called on the Root command "), nil
 	}
-	booleanFlags := make(map[string]struct{}) // change 10 to something better later ? ( or let append handle the sizing?)
-
+	booleanFlags := make(map[string]struct{})
 	fn := func(f *flag.Flag) {
 		if f.Value.Type() == "bool" {
 			booleanFlags[f.Name] = struct{}{}
@@ -823,15 +813,11 @@ func (c *Command) getAllBooleanFlags() (error, map[string]struct{}) {
 
 	for _, cmd := range c.getAllCommands() {
 		cmd.Flags().VisitAll(fn)
-
 	}
-
-	// adding persistent flags now:
 
 	c.PersistentFlags().VisitAll(fn)
 
-	return nil, booleanFlags // assuming that even if same
-
+	return nil, booleanFlags
 }
 
 func (c *Command) mergePersistentFlags() {

--- a/command.go
+++ b/command.go
@@ -19,13 +19,12 @@ package cobra
 import (
 	"bytes"
 	"errors"
-	// "flag"
 	"fmt"
 	"io"
 	"os"
 	"strings"
 
-	flag "github.com/joshi4/pflag"
+	flag "github.com/coreos/pflag"
 )
 
 // Command is just that, a command for your application.

--- a/command.go
+++ b/command.go
@@ -647,12 +647,12 @@ func (c *Command) DebugFlags() {
 			x.flags.VisitAll(func(f *flag.Flag) {
 				if x.HasPersistentFlags() {
 					if x.persistentFlag(f.Name) == nil {
-						c.Println("--"+f.Name, "["+f.DefValue+"]", "", f.Value, "  [L]")
+						c.Println(" -"+f.Shorthand+",", "--"+f.Name, "["+f.DefValue+"]", "", f.Value, "  [L]")
 					} else {
-						c.Println("--"+f.Name, "["+f.DefValue+"]", "", f.Value, "  [LP]")
+						c.Println(" -"+f.Shorthand+",", "--"+f.Name, "["+f.DefValue+"]", "", f.Value, "  [LP]")
 					}
 				} else {
-					c.Println("--"+f.Name, "["+f.DefValue+"]", "", f.Value, "  [L]")
+					c.Println(" -"+f.Shorthand+",", "--"+f.Name, "["+f.DefValue+"]", "", f.Value, "  [L]")
 				}
 			})
 		}
@@ -660,10 +660,10 @@ func (c *Command) DebugFlags() {
 			x.pflags.VisitAll(func(f *flag.Flag) {
 				if x.HasFlags() {
 					if x.flags.Lookup(f.Name) == nil {
-						c.Println("--"+f.Name, "["+f.DefValue+"]", "", f.Value, "  [P]")
+						c.Println(" -"+f.Shorthand+",", "--"+f.Name, "["+f.DefValue+"]", "", f.Value, "  [P]")
 					}
 				} else {
-					c.Println("--"+f.Name, "["+f.DefValue+"]", "", f.Value, "  [P]")
+					c.Println(" -"+f.Shorthand+",", "--"+f.Name, "["+f.DefValue+"]", "", f.Value, "  [P]")
 				}
 			})
 		}

--- a/command.go
+++ b/command.go
@@ -570,12 +570,12 @@ func (c *Command) DebugFlags() {
 			x.flags.VisitAll(func(f *flag.Flag) {
 				if x.HasPersistentFlags() {
 					if x.persistentFlag(f.Name) == nil {
-						c.Println("  -"+f.Shorthand+",", "--"+f.Name, "["+f.DefValue+"]", "", f.Value, "  [L]")
+						c.Println("--"+f.Name, "["+f.DefValue+"]", "", f.Value, "  [L]")
 					} else {
-						c.Println("  -"+f.Shorthand+",", "--"+f.Name, "["+f.DefValue+"]", "", f.Value, "  [LP]")
+						c.Println("--"+f.Name, "["+f.DefValue+"]", "", f.Value, "  [LP]")
 					}
 				} else {
-					c.Println("  -"+f.Shorthand+",", "--"+f.Name, "["+f.DefValue+"]", "", f.Value, "  [L]")
+					c.Println("--"+f.Name, "["+f.DefValue+"]", "", f.Value, "  [L]")
 				}
 			})
 		}
@@ -583,10 +583,10 @@ func (c *Command) DebugFlags() {
 			x.pflags.VisitAll(func(f *flag.Flag) {
 				if x.HasFlags() {
 					if x.flags.Lookup(f.Name) == nil {
-						c.Println("  -"+f.Shorthand+",", "--"+f.Name, "["+f.DefValue+"]", "", f.Value, "  [P]")
+						c.Println("--"+f.Name, "["+f.DefValue+"]", "", f.Value, "  [P]")
 					}
 				} else {
-					c.Println("  -"+f.Shorthand+",", "--"+f.Name, "["+f.DefValue+"]", "", f.Value, "  [P]")
+					c.Println("--"+f.Name, "["+f.DefValue+"]", "", f.Value, "  [P]")
 				}
 			})
 		}

--- a/command.go
+++ b/command.go
@@ -281,7 +281,7 @@ func (c *Command) Find(arrs []string) (*Command, []string, error) {
 	innerfind = func(c *Command, args []string) (*Command, []string) {
 		if len(args) > 0 && c.HasSubCommands() {
 			argsWOflags := stripFlags(args)
-			fmt.Println("Arguments without flags are ", argsWOflags)
+			// fmt.Println("Arguments without flags are ", argsWOflags)
 			if len(argsWOflags) > 0 {
 				matches := make([]*Command, 0)
 				for _, cmd := range c.commands {
@@ -333,7 +333,7 @@ func (c *Command) findAndExecute(args []string) (err error) {
 	if e != nil {
 		return e
 	}
-	fmt.Println("about to execute ", cmd.Name())
+	// fmt.Println("about to execute ", cmd.Name())
 	return cmd.execute(a)
 }
 
@@ -456,9 +456,9 @@ func (c *Command) Execute() (err error) {
 	}
 
 	//reformat the arguments here:
-	fmt.Println("before reformat", args_old)
+	// fmt.Println("before reformat", args_old)
 	args := c.reformatArgs(args_old)
-	fmt.Println("after reformat", args)
+	// fmt.Println("after reformat", args)
 
 	if len(args) == 0 {
 		// Only the executable is called and the root is runnable, run it
@@ -468,11 +468,11 @@ func (c *Command) Execute() (err error) {
 			c.Usage()
 		}
 	} else {
-		fmt.Println("args to findAndExecute are : ", args)
+		// fmt.Println("args to findAndExecute are : ", args)
 		err = c.findAndExecute(args)
 		if err != nil {
 
-			fmt.Println("finished findAndExecute with error = ", err.Error())
+			// fmt.Println("finished findAndExecute with error = ", err.Error())
 		}
 	}
 

--- a/command.go
+++ b/command.go
@@ -392,27 +392,20 @@ func (c *Command) reformatArgs(args []string) []string {
 	// if the value is not present, do nothing error will be caught later on.
 
 	_, booleanFlagMap := c.getAllBooleanFlags()
-	flagTerminator := false
-	argNumber := len(args)
-	modifiedArgs := make([]string, argNumber)
-	j := 0
-	for i := 0; i < argNumber; i++ {
 
-		if flagTerminator {
-			modifiedArgs[j] = args[i]
-			j += 1
-			continue
-		}
+	argNumber := len(args)
+	modifiedArgs := make([]string, 0)
+	// j := 0
+	for i := 0; i < argNumber; i++ {
 
 		if strings.HasPrefix(args[i], "-") { // its a flag.
 
 			//edge case when it's a flag terminator
 			if args[i] == "--" {
 				// everything from this point on is copied as is:
-				flagTerminator = true
-				modifiedArgs[j] = args[i]
-				j += 1
-				continue
+
+				modifiedArgs = append(modifiedArgs, args[i:]...)
+				break
 			}
 
 			if !strings.Contains(args[i], "=") { // without an equal to sign in it.
@@ -422,25 +415,25 @@ func (c *Command) reformatArgs(args []string) []string {
 				}
 				if _, ok := booleanFlagMap[args[i][num_minuses:]]; !ok { // its not a boolean flag.
 					if i+1 < argNumber { // there should be a value following it.
-						modifiedArgs[j] = strings.Join(args[i:i+2], "=")
-						j += 1
+						modifiedArgs = append(modifiedArgs, strings.Join(args[i:i+2], "="))
+						// j += 1
 						i = i + 1 // the loop will increment once as well giving us desired i+2
 						continue
 					}
 				} else { // its a boolean flag without a value specified so must be set to true.
-					modifiedArgs[j] = args[i]
-					j += 1
+					modifiedArgs = append(modifiedArgs, args[i])
+					// j += 1
 				}
 			} else { // it's a flag with an equal to sign in it.
-				modifiedArgs[j] = args[i]
-				j += 1
+				modifiedArgs = append(modifiedArgs, args[i])
+				// j += 1
 			}
 
 			continue
 		}
 
-		modifiedArgs[j] = args[i]
-		j += 1
+		modifiedArgs = append(modifiedArgs, args[i])
+		// j += 1
 
 	}
 

--- a/command.go
+++ b/command.go
@@ -23,7 +23,7 @@ import (
 	"os"
 	"strings"
 
-	flag "github.com/joshi4/pflag"
+	flag "github.com/joshi4/goflag"
 )
 
 // Command is just that, a command for your application.

--- a/command.go
+++ b/command.go
@@ -19,6 +19,7 @@ package cobra
 import (
 	"bytes"
 	"errors"
+	// "flag"
 	"fmt"
 	"io"
 	"os"
@@ -391,12 +392,29 @@ func (c *Command) reformatArgs(args []string) []string {
 	// if the value is not present, do nothing error will be caught later on.
 
 	_, booleanFlagMap := c.getAllBooleanFlags()
-
+	flagTerminator := false
 	argNumber := len(args)
 	modifiedArgs := make([]string, argNumber)
 	j := 0
 	for i := 0; i < argNumber; i++ {
+
+		if flagTerminator {
+			modifiedArgs[j] = args[i]
+			j += 1
+			continue
+		}
+
 		if strings.HasPrefix(args[i], "-") { // its a flag.
+
+			//edge case when it's a flag terminator
+			if args[i] == "--" {
+				// everything from this point on is copied as is:
+				flagTerminator = true
+				modifiedArgs[j] = args[i]
+				j += 1
+				continue
+			}
+
 			if !strings.Contains(args[i], "=") { // without an equal to sign in it.
 				num_minuses := 1
 				if len(args[i]) > 1 && args[i][1] == '-' {
@@ -447,18 +465,16 @@ func (c *Command) Execute() (err error) {
 	// solution is: convert args to have -flag val -> -flag=val
 	// that should be the last thing I have to take care of.
 
-	var args_old []string
+	var args []string
 
 	if len(c.args) == 0 {
-		args_old = os.Args[1:]
+		args = os.Args[1:]
 	} else {
-		args_old = c.args
+		args = c.args
 	}
 
 	//reformat the arguments here:
-	// fmt.Println("before reformat", args_old)
-	args := c.reformatArgs(args_old)
-	// fmt.Println("after reformat", args)
+	args = c.reformatArgs(args)
 
 	if len(args) == 0 {
 		// Only the executable is called and the root is runnable, run it


### PR DESCRIPTION
Because cobra was written with pflags in mind, changing pflags makes it necessary to change cobra. The strip flags function works on the POSIX style of flags. I found that instead of rewriting that function to support the much wider range of flags accepted now, it would be much easier and quicker to add a reformatArgs() function which would take in arguments in the original goflags style and convert them to the style that pflags expects. 

Major changes to review: reformatArgs(), getAllBooleanFlags() 
